### PR TITLE
test: stabilize frontend unit tests

### DIFF
--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -6,4 +6,5 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint'],
+  ignorePatterns: ['vitest.config.ts'],
 }

--- a/apps/frontend/src/test/__mocks__/antd-icons.ts
+++ b/apps/frontend/src/test/__mocks__/antd-icons.ts
@@ -1,0 +1,26 @@
+import React from 'react'
+
+const createIcon =
+  (name: string) => (props: React.HTMLAttributes<HTMLSpanElement>) =>
+    React.createElement('span', { 'data-testid': `${name}-icon`, ...props })
+
+export const PhoneOutlined = createIcon('phone')
+export const MailOutlined = createIcon('mail')
+export const VideoCameraOutlined = createIcon('video-camera')
+export const MessageOutlined = createIcon('message')
+export const UserOutlined = createIcon('user')
+export const ShoppingCartOutlined = createIcon('shopping-cart')
+export const FileTextOutlined = createIcon('file-text')
+export const CalendarOutlined = createIcon('calendar')
+export const BellOutlined = createIcon('bell')
+export const HeartOutlined = createIcon('heart')
+export const ShareAltOutlined = createIcon('share-alt')
+export const EyeOutlined = createIcon('eye')
+export const EditOutlined = createIcon('edit')
+export const DeleteOutlined = createIcon('delete')
+export const DownloadOutlined = createIcon('download')
+export const UploadOutlined = createIcon('upload')
+export const LoginOutlined = createIcon('login')
+export const LogoutOutlined = createIcon('logout')
+export const SettingOutlined = createIcon('setting')
+export const QuestionCircleOutlined = createIcon('question-circle')

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom'
+import { cleanup } from '@testing-library/react'
 import { vi } from 'vitest'
 import React from 'react'
 
@@ -9,9 +10,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Clean up any pending timers
+  // Clean up any pending timers and mocks
+  cleanup()
   vi.clearAllTimers()
   vi.clearAllMocks()
+  vi.restoreAllMocks()
 })
 
 // Global error handler for tests
@@ -22,9 +25,9 @@ console.error = vi.fn().mockImplementation((...args) => {
   if (
     typeof message === 'string' &&
     (message.includes('Warning: ReactDOM.render is no longer supported') ||
-     message.includes('Warning: findDOMNode') ||
-     message.includes('Warning: componentWillReceiveProps') ||
-     message.includes('Warning: componentWillUpdate'))
+      message.includes('Warning: findDOMNode') ||
+      message.includes('Warning: componentWillReceiveProps') ||
+      message.includes('Warning: componentWillUpdate'))
   ) {
     return
   }
@@ -49,52 +52,75 @@ vi.mock('../config/env', () => ({
 
 // Mock Ant Design icons with dynamic proxy
 vi.mock('@ant-design/icons', () => {
-  const iconMocks = new Proxy({}, {
-    get: (target, prop) => {
-      if (typeof prop === 'string' && prop.endsWith('Outlined')) {
-        return vi.fn(() => {
-          const iconName = prop.replace('Outlined', '').toLowerCase()
-          const testId = iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
-          return React.createElement('span', { 
-            'data-testid': testId,
-            'aria-label': prop
-          }, '🔸')
-        })
-      }
-      if (typeof prop === 'string' && prop.endsWith('Filled')) {
-        return vi.fn(() => {
-          const iconName = prop.replace('Filled', '').toLowerCase()
-          const testId = iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
-          return React.createElement('span', { 
-            'data-testid': testId,
-            'aria-label': prop
-          }, '🔹')
-        })
-      }
-      if (typeof prop === 'string' && prop.endsWith('TwoTone')) {
-        return vi.fn(() => {
-          const iconName = prop.replace('TwoTone', '').toLowerCase()
-          const testId = iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
-          return React.createElement('span', { 
-            'data-testid': testId,
-            'aria-label': prop
-          }, '🔷')
-        })
-      }
-      // Default fallback for any other icon patterns
-      if (typeof prop === 'string') {
-        return vi.fn(() => {
-          const testId = prop.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
-          return React.createElement('span', { 
-            'data-testid': testId,
-            'aria-label': prop
-          }, '🔸')
-        })
-      }
-      return undefined
+  const iconMocks = new Proxy(
+    {},
+    {
+      get: (target, prop) => {
+        if (typeof prop === 'string' && prop.endsWith('Outlined')) {
+          return vi.fn(() => {
+            const iconName = prop.replace('Outlined', '').toLowerCase()
+            const testId =
+              iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
+            return React.createElement(
+              'span',
+              {
+                'data-testid': testId,
+                'aria-label': prop,
+              },
+              '🔸'
+            )
+          })
+        }
+        if (typeof prop === 'string' && prop.endsWith('Filled')) {
+          return vi.fn(() => {
+            const iconName = prop.replace('Filled', '').toLowerCase()
+            const testId =
+              iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
+            return React.createElement(
+              'span',
+              {
+                'data-testid': testId,
+                'aria-label': prop,
+              },
+              '🔹'
+            )
+          })
+        }
+        if (typeof prop === 'string' && prop.endsWith('TwoTone')) {
+          return vi.fn(() => {
+            const iconName = prop.replace('TwoTone', '').toLowerCase()
+            const testId =
+              iconName.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
+            return React.createElement(
+              'span',
+              {
+                'data-testid': testId,
+                'aria-label': prop,
+              },
+              '🔷'
+            )
+          })
+        }
+        // Default fallback for any other icon patterns
+        if (typeof prop === 'string') {
+          return vi.fn(() => {
+            const testId =
+              prop.replace(/([A-Z])/g, '-$1').toLowerCase() + '-icon'
+            return React.createElement(
+              'span',
+              {
+                'data-testid': testId,
+                'aria-label': prop,
+              },
+              '🔸'
+            )
+          })
+        }
+        return undefined
+      },
     }
-  })
-  
+  )
+
   return iconMocks
 })
 
@@ -161,10 +187,10 @@ console.warn = vi.fn().mockImplementation((...args) => {
   if (
     typeof message === 'string' &&
     (message.includes('findDOMNode') ||
-     message.includes('destroyInactiveTabPane') ||
-     message.includes('strokeWidth') ||
-     message.includes('overlayStyle') ||
-     message.includes('overlayClassName'))
+      message.includes('destroyInactiveTabPane') ||
+      message.includes('strokeWidth') ||
+      message.includes('overlayStyle') ||
+      message.includes('overlayClassName'))
   ) {
     return
   }
@@ -194,4 +220,10 @@ const sessionStorageMock = {
 }
 Object.defineProperty(window, 'sessionStorage', {
   value: sessionStorageMock,
+})
+
+afterAll(() => {
+  // Restore original console methods
+  console.error = originalError
+  console.warn = originalWarn
 })

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     testTimeout: 60000, // 1 minuto por test
     hookTimeout: 30000, // 30 segundos para hooks
     teardownTimeout: 10000, // 10 segundos para cleanup
-    
+
     // Configuración para estabilidad y rendimiento
     pool: 'forks',
     poolOptions: {
@@ -22,11 +22,11 @@ export default defineConfig({
         isolate: true,
       },
     },
-    
+
     // Configuración para evitar tests colgados
     bail: 1, // Parar en el primer fallo
     retry: 1, // Reintentar una vez si falla
-    
+
     // Excluir archivos del sistema
     exclude: [
       '**/node_modules/**',
@@ -34,10 +34,10 @@ export default defineConfig({
       '**/coverage/**',
       '**/storybook-static/**',
     ],
-    
+
     // Configuración para reportes
     reporters: ['verbose'],
-    
+
     // Configuración para coverage
     coverage: {
       provider: 'v8',
@@ -67,6 +67,10 @@ export default defineConfig({
       '@/utils': resolve(__dirname, './src/utils'),
       '@/types': resolve(__dirname, './src/types'),
       '@/assets': resolve(__dirname, './src/assets'),
+      '@ant-design/icons': resolve(
+        __dirname,
+        './src/test/__mocks__/antd-icons.ts'
+      ),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add global cleanup and restore console methods in test setup
- stub `@ant-design/icons` to speed up Vitest runs
- ignore `vitest.config.ts` in ESLint for frontend

## Testing
- `pnpm test src/components/atoms/Badge/Badge.test.tsx --reporter=basic`
- `timeout 120s pnpm test src/components/atoms/ActivityIcon/ActivityIcon.test.tsx --reporter=basic` *(times out; needs further optimization)*

------
https://chatgpt.com/codex/tasks/task_e_68a4944876e8832b87a7f3c27b1e055a