### PR TITLE
fix: use pnpm in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -93,6 +94,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -107,9 +123,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Dependency vulnerability scan
-        run: |
-          npm audit --audit-level moderate
-          pnpm audit --audit-level moderate
+        run: pnpm audit --audit-level moderate
 
   # Build y push de imágenes Docker
   build:


### PR DESCRIPTION
## Summary
- use pnpm cache and lockfile for setup-node
- install dependencies and audit with pnpm only in security job

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: Parsing error: Unexpected token interface)*
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aa393b1c832b862226aeaf5bca8e