### PR TITLE
fix: correct product analytics comment and tsconfig references

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,9 @@ module.exports = {
     es2020: true,
     node: true,
   },
-  extends: ['eslint:recommended', 'plugin:storybook/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:storybook/recommended'],
   ignorePatterns: ['dist', '.eslintrc.js', 'node_modules', '**/*.d.ts'],
   parserOptions: {
     ecmaVersion: 'latest',

--- a/apps/backend/src/routes/products.ts
+++ b/apps/backend/src/routes/products.ts
@@ -346,8 +346,7 @@ router.get('/:id/variants',
     }
   }
 )
-/
-/ GET /products/analytics/overview - Get product analytics overview
+// GET /products/analytics/overview - Get product analytics overview
 router.get('/analytics/overview',
   authorize(['products:read', 'analytics:read']),
   async (req, res, next) => {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -31,7 +31,7 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "src/test"],
   "references": [
     {
       "path": "../../packages/shared"

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -37,9 +37,6 @@
       "path": "../../packages/shared"
     },
     {
-      "path": "../../packages/ui"
-    },
-    {
       "path": "../../packages/types"
     },
     {


### PR DESCRIPTION
## Summary
- fix malformed comment in products analytics route
- remove non-existent package reference from frontend tsconfig
- configure ESLint for TypeScript parsing
- exclude backend tests from TypeScript build

## Testing
- `pnpm audit --audit-level moderate` *(fails: esbuild vulnerability)*
- `pnpm run type-check` *(fails: property 'type' does not exist on type 'WebhookEvent', etc.)*
- `pnpm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1d32088832b8286a59ff06a77ae