### PR TITLE
chore: remove unused order routes import

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -49,7 +49,6 @@ import healthRoutes from './routes/health'
 import cacheRoutes from './routes/cache'
 import inventoryRoutes, { initializeInventoryRoutes } from './routes/inventory'
 import customerRoutes from './routes/customers'
-import orderRoutes from './routes/orders'
 import simpleRoutes from './routes/simple.js'
 
 // Import Swagger setup


### PR DESCRIPTION
## Summary
- remove unused order routes from backend entrypoint

## Testing
- `pnpm exec eslint apps/backend/src/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4be01f164832bbd97f00cc124fde2