### PR TITLE
fix: run lint-staged via npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm lint-staged
+npx --no-install lint-staged
+


### PR DESCRIPTION
## Summary
- use `npx lint-staged` in pre-commit hook to avoid missing pnpm

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4da410b30832bb626f09ffad6dcd8