### PR TITLE
fix: update backend tests to expect ISO date strings

### DIFF
--- a/apps/backend/src/test/customer.routes.test.ts
+++ b/apps/backend/src/test/customer.routes.test.ts
@@ -54,8 +54,8 @@ describe('Customer Routes', () => {
     emailOptIn: true,
     smsOptIn: false,
     tags: ['vip'],
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
     deletedAt: null,
     addresses: [],
     segmentMembers: [],
@@ -185,7 +185,7 @@ describe('Customer Routes', () => {
         type: 'order',
         title: 'Order ORD-001',
         description: 'Order for $100 with 1 items',
-        date: new Date('2023-01-01'),
+        date: new Date('2023-01-01').toISOString(),
         metadata: { orderId: 'order-1' },
       },
     ]
@@ -374,7 +374,7 @@ describe('Customer Routes', () => {
       subject: 'Support request',
       content: 'Customer needs help with order',
       outcome: 'sent',
-      createdAt: new Date(),
+      createdAt: new Date().toISOString(),
     }
 
     it('should add interaction successfully', async () => {
@@ -565,8 +565,8 @@ describe('Customer Routes', () => {
       description: 'High value customers',
       rules: segmentData.conditions,
       isActive: true,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     }
 
     it('should create segment successfully', async () => {

--- a/apps/backend/src/test/order.payment.test.ts
+++ b/apps/backend/src/test/order.payment.test.ts
@@ -66,9 +66,9 @@ describe('Order Payment Integration Tests', () => {
           productId: 'product-1',
           quantity: 2,
           price: 29.99,
-          total: 59.98
-        }
-      ]
+          total: 59.98,
+        },
+      ],
     } as any)
 
     // Mock other Prisma methods
@@ -77,12 +77,12 @@ describe('Order Payment Integration Tests', () => {
       orderId: 'order-1',
       amount: 59.98,
       currency: 'USD',
-      status: PaymentStatus.COMPLETED
+      status: PaymentStatus.COMPLETED,
     } as any)
 
     vi.mocked(prisma.order.update).mockResolvedValue({
       id: 'order-1',
-      status: OrderStatus.CONFIRMED
+      status: OrderStatus.CONFIRMED,
     } as any)
 
     // Setup WebSocket service mock
@@ -92,7 +92,12 @@ describe('Order Payment Integration Tests', () => {
     }
 
     vi.clearAllMocks()
-    orderService = new OrderService(undefined, undefined, undefined, mockWebSocketService)
+    orderService = new OrderService(
+      undefined,
+      undefined,
+      undefined,
+      mockWebSocketService
+    )
     _paymentGatewayService = new PaymentGatewayService()
   })
 
@@ -423,7 +428,9 @@ describe('Order Payment Integration Tests', () => {
       const result = await stripeGateway.processPayment(paymentRequest)
 
       expect(result.success).toBeDefined()
-      expect([PaymentStatus.COMPLETED, PaymentStatus.FAILED]).toContain(result.status)
+      expect([PaymentStatus.COMPLETED, PaymentStatus.FAILED]).toContain(
+        result.status
+      )
       if (result.success) {
         expect(result.transactionId).toMatch(/^pi_/)
         expect(result.metadata?.gateway).toBe('stripe')
@@ -445,7 +452,9 @@ describe('Order Payment Integration Tests', () => {
       const result = await paypalGateway.processPayment(paymentRequest)
 
       expect(result.success).toBeDefined()
-      expect([PaymentStatus.COMPLETED, PaymentStatus.FAILED]).toContain(result.status)
+      expect([PaymentStatus.COMPLETED, PaymentStatus.FAILED]).toContain(
+        result.status
+      )
       if (result.success) {
         expect(result.transactionId).toMatch(/^PAY-/)
         expect(result.metadata?.gateway).toBe('paypal')
@@ -541,7 +550,7 @@ describe('Order Payment Integration Tests', () => {
             update: vi.fn().mockResolvedValue({
               ...paidOrder,
               status: OrderStatus.CANCELLED,
-              cancelledAt: new Date(),
+              cancelledAt: new Date().toISOString(),
               financialStatus: FinancialStatus.REFUNDED,
             }),
           },


### PR DESCRIPTION
## Summary
- adjust customer route tests to assert ISO date strings
- ensure order payment tests use ISO strings for cancellation dates

## Testing
- `pnpm --filter @oda/backend exec eslint src/test/customer.routes.test.ts src/test/order.payment.test.ts --max-warnings 0`
- `pnpm --filter @oda/backend test src/test/customer.routes.test.ts src/test/order.payment.test.ts` *(fails: Failed to resolve entry for package "@oda/shared" and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50a9e4dc832b93655b8d609cc6ec