### PR TITLE
chore: remove e2e tests from workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,12 +72,6 @@ jobs:
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
           REDIS_URL: redis://localhost:6379
 
-      - name: E2E tests
-        run: pnpm run test:e2e
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
-          REDIS_URL: redis://localhost:6379
-
       - name: Build applications
         run: pnpm run build
 


### PR DESCRIPTION
## Summary
- remove nonexistent e2e test step from CI workflow

## Testing
- `pnpm run lint` (fails: 29 errors, 126 warnings)
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ae70a31170832b9a77cbc4b4ffcbcf