### PR TITLE
fix prisma module imports

### DIFF
--- a/apps/backend/src/lib/cache/cache-warming.ts
+++ b/apps/backend/src/lib/cache/cache-warming.ts
@@ -1,5 +1,5 @@
 import logger from '../logger.js'
-import { prisma } from '../prisma.js'
+import { prisma } from '../prisma'
 
 import { cacheManager, CacheOptions } from './cache-manager.js'
 

--- a/apps/backend/src/lib/database-health.ts
+++ b/apps/backend/src/lib/database-health.ts
@@ -1,6 +1,6 @@
 import { env } from '../config/env.js'
 
-import { prisma } from './prisma.js'
+import { prisma } from './prisma'
 import logger from './logger'
 
 export interface HealthCheckResult {

--- a/apps/backend/src/routes/categories.ts
+++ b/apps/backend/src/routes/categories.ts
@@ -2,10 +2,15 @@ import { productCategorySchema, commonValidationSchemas } from '@oda/shared'
 import { Router } from 'express'
 import { z } from 'zod'
 
-import { sendSuccess, sendCreated, sendError, sendNotFound } from '../lib/api-response.js'
+import {
+  sendSuccess,
+  sendCreated,
+  sendError,
+  sendNotFound,
+} from '../lib/api-response.js'
 import { CacheManager } from '../lib/cache/cache-manager.js'
 import { logger } from '../lib/logger.js'
-import { prisma } from '../lib/prisma.js'
+import { prisma } from '../lib/prisma'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { validate, xssProtection } from '../middleware/validation.js'
 
@@ -186,7 +191,7 @@ router.get(
         return sendNotFound(res, 'Category')
       }
 
-        sendSuccess(res, { category })
+      sendSuccess(res, { category })
     } catch (error) {
       next(error)
     }
@@ -214,7 +219,7 @@ router.post(
           where: { id: categoryData.parentId, isActive: true },
         })
         if (!parentCategory) {
-                  return sendNotFound(res, 'Parent category')
+          return sendNotFound(res, 'Parent category')
         }
       }
 
@@ -223,7 +228,12 @@ router.post(
         where: { slug: categoryData.slug },
       })
       if (existingCategory) {
-        return sendError(res, 'DUPLICATE_SLUG', 'Category with this slug already exists', 400)
+        return sendError(
+          res,
+          'DUPLICATE_SLUG',
+          'Category with this slug already exists',
+          400
+        )
       }
 
       const newCategory = await prisma.category.create({
@@ -297,13 +307,18 @@ router.put(
           where: { id: updateData.parentId, isActive: true },
         })
         if (!parentCategory) {
-                  return sendNotFound(res, 'Parent category')
+          return sendNotFound(res, 'Parent category')
         }
 
         // Prevent circular references
         const isCircular = await checkCircularReference(id, updateData.parentId)
         if (isCircular) {
-          return sendError(res, 'CIRCULAR_REFERENCE', 'Cannot create circular category reference', 400)
+          return sendError(
+            res,
+            'CIRCULAR_REFERENCE',
+            'Cannot create circular category reference',
+            400
+          )
         }
       }
 
@@ -316,7 +331,12 @@ router.put(
           },
         })
         if (duplicateSlug) {
-          return sendError(res, 'DUPLICATE_SLUG', 'Category with this slug already exists', 400)
+          return sendError(
+            res,
+            'DUPLICATE_SLUG',
+            'Category with this slug already exists',
+            400
+          )
         }
       }
 
@@ -365,7 +385,8 @@ router.put(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { category: updatedCategory },
         'Category updated successfully'
       )
@@ -411,12 +432,22 @@ router.delete(
 
       // Check if category has products
       if (category._count.products > 0) {
-        return sendError(res, 'CATEGORY_HAS_PRODUCTS', 'Cannot delete category with products. Move products to another category first.', 400)
+        return sendError(
+          res,
+          'CATEGORY_HAS_PRODUCTS',
+          'Cannot delete category with products. Move products to another category first.',
+          400
+        )
       }
 
       // Check if category has children
       if (category.children.length > 0) {
-        return sendError(res, 'CATEGORY_HAS_CHILDREN', 'Cannot delete category with subcategories. Delete or move subcategories first.', 400)
+        return sendError(
+          res,
+          'CATEGORY_HAS_CHILDREN',
+          'Cannot delete category with subcategories. Delete or move subcategories first.',
+          400
+        )
       }
 
       await prisma.category.delete({
@@ -431,10 +462,7 @@ router.delete(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
-        null,
-        'Category deleted successfully'
-      )
+      const response = sendSuccess(res, null, 'Category deleted successfully')
       res.json(response)
     } catch (error) {
       next(error)
@@ -471,7 +499,8 @@ router.post(
       // Clear category caches
       await cache.clear('categories')
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { category: updatedCategory },
         'Category reordered successfully'
       )

--- a/apps/backend/src/routes/collections.ts
+++ b/apps/backend/src/routes/collections.ts
@@ -2,10 +2,15 @@ import { productCollectionSchema, commonValidationSchemas } from '@oda/shared'
 import { Router } from 'express'
 import { z } from 'zod'
 
-import { sendSuccess, sendCreated, sendError, sendPaginated } from '../lib/api-response.js'
+import {
+  sendSuccess,
+  sendCreated,
+  sendError,
+  sendPaginated,
+} from '../lib/api-response.js'
 import { CacheManager } from '../lib/cache/cache-manager.js'
 import { logger } from '../lib/logger.js'
-import { prisma } from '../lib/prisma.js'
+import { prisma } from '../lib/prisma'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { validate, xssProtection } from '../middleware/validation.js'
 
@@ -192,7 +197,12 @@ router.post(
         where: { slug: collectionData.slug },
       })
       if (existingCollection) {
-        return sendError(res, 'DUPLICATE_SLUG', 'Collection with this slug already exists', 400)
+        return sendError(
+          res,
+          'DUPLICATE_SLUG',
+          'Collection with this slug already exists',
+          400
+        )
       }
 
       const newCollection = await prisma.collection.create({
@@ -269,7 +279,12 @@ router.put(
           },
         })
         if (duplicateSlug) {
-          return sendError(res, 'DUPLICATE_SLUG', 'Collection with this slug already exists', 400)
+          return sendError(
+            res,
+            'DUPLICATE_SLUG',
+            'Collection with this slug already exists',
+            400
+          )
         }
       }
 
@@ -317,7 +332,8 @@ router.put(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { collection: updatedCollection },
         'Collection updated successfully'
       )
@@ -373,10 +389,7 @@ router.delete(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
-        null,
-        'Collection deleted successfully'
-      )
+      const response = sendSuccess(res, null, 'Collection deleted successfully')
       res.json(response)
     } catch (error) {
       next(error)
@@ -424,11 +437,14 @@ router.post(
 
       if (existingProducts.length !== productIds.length) {
         const foundIds = existingProducts.map((p) => p.id)
-        const missingIds = productIds.filter((id: string) => !foundIds.includes(id))
+        const missingIds = productIds.filter(
+          (id: string) => !foundIds.includes(id)
+        )
         return res
           .status(404)
           .json(
-            sendError(res, 
+            sendError(
+              res,
               'PRODUCTS_NOT_FOUND',
               `Products not found: ${missingIds.join(', ')}`,
               404
@@ -445,11 +461,13 @@ router.post(
       const startSortOrder = (maxSortOrder._max.sortOrder || 0) + 1
 
       // Add products to collection (ignore duplicates)
-      const collectionProducts = productIds.map((productId: string, index: number) => ({
-        collectionId: id,
-        productId,
-        sortOrder: startSortOrder + index,
-      }))
+      const collectionProducts = productIds.map(
+        (productId: string, index: number) => ({
+          collectionId: id,
+          productId,
+          sortOrder: startSortOrder + index,
+        })
+      )
 
       await prisma.collectionProduct.createMany({
         data: collectionProducts,
@@ -477,7 +495,8 @@ router.post(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         {
           collection: updatedCollection,
           addedCount: productIds.length,
@@ -549,7 +568,8 @@ router.delete(
         userId: req.user?.id,
       })
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         {
           collection: updatedCollection,
           removedCount: result.count,
@@ -592,7 +612,8 @@ router.post(
       // Clear collection caches
       await cache.clear('collections:*')
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { collection: updatedCollection },
         'Collection reordered successfully'
       )
@@ -647,7 +668,8 @@ router.post(
       // Clear collection caches
       await cache.clear('collections:*')
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { reorderedCount: productOrders.length },
         'Products reordered successfully'
       )

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -3,7 +3,7 @@ import { Router } from 'express'
 import { sendSuccess, sendError } from '../lib/api-response.js'
 import { databaseHealthChecker } from '../lib/database-health.js'
 import { databasePool } from '../lib/database-pool.js'
-import { getDatabaseMetrics } from '../lib/prisma.js'
+import { getDatabaseMetrics } from '../lib/prisma'
 import { asyncHandler } from '../middleware/error-handler'
 
 const router: Router = Router()

--- a/apps/backend/src/routes/products.ts
+++ b/apps/backend/src/routes/products.ts
@@ -13,10 +13,15 @@ import { Router } from 'express'
 import multer from 'multer'
 import { z } from 'zod'
 
-import { sendSuccess, sendCreated, sendError, sendPaginated } from '../lib/api-response.js'
+import {
+  sendSuccess,
+  sendCreated,
+  sendError,
+  sendPaginated,
+} from '../lib/api-response.js'
 import { CacheManager } from '../lib/cache/cache-manager.js'
 import { logger } from '../lib/logger.js'
-import { prisma } from '../lib/prisma.js'
+import { prisma } from '../lib/prisma'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { validate, xssProtection } from '../middleware/validation.js'
 import { AnalyticsService } from '../services/analytics.service.js'
@@ -70,16 +75,22 @@ router.get(
 
       const result = await productService.searchProducts(query)
 
-      sendPaginated(res, result.products, {
-        page: query.page || 1,
-        limit: query.limit || 20,
-        total: result.total,
-        totalPages: Math.ceil(result.total / (query.limit || 20)),
-        hasNext: (query.page || 1) < Math.ceil(result.total / (query.limit || 20)),
-        hasPrev: (query.page || 1) > 1,
-      }, {
-        facets: result.facets,
-      })
+      sendPaginated(
+        res,
+        result.products,
+        {
+          page: query.page || 1,
+          limit: query.limit || 20,
+          total: result.total,
+          totalPages: Math.ceil(result.total / (query.limit || 20)),
+          hasNext:
+            (query.page || 1) < Math.ceil(result.total / (query.limit || 20)),
+          hasPrev: (query.page || 1) > 1,
+        },
+        {
+          facets: result.facets,
+        }
+      )
     } catch (error) {
       next(error)
     }
@@ -227,7 +238,8 @@ router.post(
         req.user?.id
       )
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         result,
         `${result.updatedCount} products updated successfully`
       )
@@ -257,7 +269,8 @@ router.delete(
         req.user?.id
       )
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         result,
         `${result.deletedCount} products deleted successfully`
       )
@@ -292,7 +305,9 @@ router.post(
       // Check if product exists
       const product = await productService.getProduct(id)
       if (!product) {
-        return res.status(404).json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
+        return res
+          .status(404)
+          .json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
       }
 
       // Process images
@@ -319,7 +334,8 @@ router.post(
         req.user?.id
       )
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         {
           images: uploadResults,
           product: updatedProduct,
@@ -350,7 +366,9 @@ router.get(
       const product = await productService.getProduct(id)
 
       if (!product) {
-        return res.status(404).json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
+        return res
+          .status(404)
+          .json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
       }
 
       const response = sendSuccess(res, { variants: product.variants })
@@ -455,7 +473,9 @@ router.post(
       if (!file) {
         return res
           .status(400)
-          .json(sendError(res, 'CSV_FILE_REQUIRED', 'CSV file is required', 400))
+          .json(
+            sendError(res, 'CSV_FILE_REQUIRED', 'CSV file is required', 400)
+          )
       }
 
       logger.info('Starting CSV product import', {
@@ -501,7 +521,9 @@ router.post(
       if (!file) {
         return res
           .status(400)
-          .json(sendError(res, 'JSON_FILE_REQUIRED', 'JSON file is required', 400))
+          .json(
+            sendError(res, 'JSON_FILE_REQUIRED', 'JSON file is required', 400)
+          )
       }
 
       logger.info('Starting JSON product import', {
@@ -560,10 +582,7 @@ router.post(
         }
       )
 
-      const response = sendSuccess(res, 
-        result,
-        'Export completed successfully'
-      )
+      const response = sendSuccess(res, result, 'Export completed successfully')
       res.json(response)
     } catch (error) {
       next(error)
@@ -582,7 +601,14 @@ router.get(
       if (!q || typeof q !== 'string') {
         return res
           .status(400)
-          .json(sendError(res, 'QUERY_PARAMETER_REQUIRED', 'Query parameter "q" is required', 400))
+          .json(
+            sendError(
+              res,
+              'QUERY_PARAMETER_REQUIRED',
+              'Query parameter "q" is required',
+              400
+            )
+          )
       }
 
       logger.info('Fetching search suggestions', {
@@ -633,7 +659,8 @@ router.post(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await searchService.reindexAllProducts(products as any)
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { reindexedCount: products.length },
         `${products.length} products reindexed successfully`
       )
@@ -667,13 +694,17 @@ router.delete(
       // Get product
       const product = await productService.getProduct(id)
       if (!product) {
-        return res.status(404).json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
+        return res
+          .status(404)
+          .json(sendError(res, 'NOT_FOUND', 'Product not found', 404))
       }
 
       // Find and remove image
       const imageIndex = product.images.findIndex((img) => img.id === imageId)
       if (imageIndex === -1) {
-        return res.status(404).json(sendError(res, 'NOT_FOUND', 'Image not found', 404))
+        return res
+          .status(404)
+          .json(sendError(res, 'NOT_FOUND', 'Image not found', 404))
       }
 
       // Delete image file
@@ -718,7 +749,8 @@ const validateProductAvailability = async (
       return res
         .status(400)
         .json(
-          sendError(res, 
+          sendError(
+            res,
             'INVENTORY_REQUIRED',
             'At least one variant must have inventory available',
             400
@@ -747,7 +779,8 @@ router.post(
         req.user?.id
       )
 
-      const response = sendSuccess(res, 
+      const response = sendSuccess(
+        res,
         { product: newProduct },
         'Product created with inventory validation'
       )

--- a/apps/backend/src/scripts/verify-database.ts
+++ b/apps/backend/src/scripts/verify-database.ts
@@ -7,7 +7,7 @@ import {
   connectDatabase,
   disconnectDatabase,
   getDatabaseMetrics,
-} from '../lib/prisma.js'
+} from '../lib/prisma'
 
 async function verifyDatabase() {
   console.log('🔍 Starting database verification...\n')

--- a/apps/backend/src/services/customer.service.ts
+++ b/apps/backend/src/services/customer.service.ts
@@ -8,7 +8,7 @@ import {
   BusinessLogicError,
 } from '../lib/errors.js'
 import logger from '../lib/logger.js'
-import { prisma } from '../lib/prisma.js'
+import { prisma } from '../lib/prisma'
 
 export interface CustomerWithRelations
   extends Prisma.CustomerGetPayload<{

--- a/apps/backend/src/test/customer.privacy.test.ts
+++ b/apps/backend/src/test/customer.privacy.test.ts
@@ -4,7 +4,7 @@ import { auditService } from '../services/audit.service.js'
 import { AppError } from '../lib/errors.js'
 
 // Mock dependencies
-vi.mock('../lib/prisma.js')
+vi.mock('../lib/prisma')
 vi.mock('../services/audit.service.js')
 vi.mock('../lib/cache/index.js')
 
@@ -32,7 +32,7 @@ const mockPrisma = {
   $transaction: vi.fn(),
 }
 
-vi.mock('../lib/prisma.js', () => ({
+vi.mock('../lib/prisma', () => ({
   prisma: mockPrisma,
 }))
 

--- a/apps/backend/src/test/customer.service.test.ts
+++ b/apps/backend/src/test/customer.service.test.ts
@@ -53,7 +53,7 @@ const mockPrisma = {
   $transaction: vi.fn(),
 }
 
-vi.mock('../lib/prisma.js', () => ({
+vi.mock('../lib/prisma', () => ({
   prisma: mockPrisma,
 }))
 

--- a/apps/backend/src/test/database.test.ts
+++ b/apps/backend/src/test/database.test.ts
@@ -4,7 +4,7 @@ import {
   connectDatabase,
   disconnectDatabase,
   getDatabaseMetrics,
-} from '../lib/prisma.js'
+} from '../lib/prisma'
 import { databaseHealthChecker } from '../lib/database-health.js'
 import { databasePool } from '../lib/database-pool.js'
 

--- a/apps/backend/src/test/product.routes.test.ts
+++ b/apps/backend/src/test/product.routes.test.ts
@@ -49,18 +49,6 @@ describe('Product Routes', () => {
       collections: 0,
     },
   }
-
-  const mockSearchResult = {
-    products: [mockProduct],
-    total: 1,
-    facets: {
-      categories: [],
-      brands: [],
-      priceRanges: [],
-      status: [],
-    },
-  }
-
   beforeAll(() => {
     app = createTestApp()
   })
@@ -72,7 +60,7 @@ describe('Product Routes', () => {
 
   describe('GET /api/products', () => {
     it('should return products with pagination', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
       prisma.product.count.mockResolvedValue(1)
 
@@ -87,7 +75,7 @@ describe('Product Routes', () => {
     })
 
     it('should apply search filters', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
       prisma.product.count.mockResolvedValue(1)
 
@@ -114,7 +102,7 @@ describe('Product Routes', () => {
 
   describe('GET /api/products/:id', () => {
     it('should return a single product', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(mockProduct)
 
       const response = await request(app)
@@ -126,7 +114,7 @@ describe('Product Routes', () => {
     })
 
     it('should return 404 for non-existent product', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(null)
 
       await request(app).get('/api/products/non-existent').expect(404)
@@ -135,7 +123,7 @@ describe('Product Routes', () => {
 
   describe('POST /api/products', () => {
     it('should create a product successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.create.mockResolvedValue(mockProduct)
       prisma.location.findFirst.mockResolvedValue({
         id: 'location-1',
@@ -177,9 +165,12 @@ describe('Product Routes', () => {
 
   describe('PUT /api/products/:id', () => {
     it('should update a product successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(mockProduct)
-      prisma.product.update.mockResolvedValue({ ...mockProduct, name: 'Updated Product' })
+      prisma.product.update.mockResolvedValue({
+        ...mockProduct,
+        name: 'Updated Product',
+      })
 
       const response = await request(app)
         .put('/api/products/product-1')
@@ -194,7 +185,7 @@ describe('Product Routes', () => {
     })
 
     it('should return 404 for non-existent product', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(null)
 
       await request(app)
@@ -206,9 +197,12 @@ describe('Product Routes', () => {
 
   describe('DELETE /api/products/:id', () => {
     it('should delete a product successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(mockProduct)
-      prisma.product.update.mockResolvedValue({ ...mockProduct, deletedAt: new Date() })
+      prisma.product.update.mockResolvedValue({
+        ...mockProduct,
+        deletedAt: new Date(),
+      })
       prisma.orderItem.count.mockResolvedValue(0)
 
       const response = await request(app)
@@ -219,7 +213,7 @@ describe('Product Routes', () => {
     })
 
     it('should return 404 for non-existent product', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(null)
 
       await request(app).delete('/api/products/non-existent').expect(404)
@@ -228,7 +222,7 @@ describe('Product Routes', () => {
 
   describe('POST /api/products/bulk-update', () => {
     it('should bulk update products successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
       prisma.product.updateMany.mockResolvedValue({ count: 1 })
 
@@ -258,7 +252,7 @@ describe('Product Routes', () => {
 
   describe('DELETE /api/products/bulk-delete', () => {
     it('should bulk delete products successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
       prisma.orderItem.count.mockResolvedValue(0)
       prisma.product.updateMany.mockResolvedValue({ count: 1 })
@@ -276,7 +270,7 @@ describe('Product Routes', () => {
 
   describe('POST /api/products/:id/images', () => {
     it('should upload product images successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(mockProduct)
 
       const response = await request(app)
@@ -292,7 +286,7 @@ describe('Product Routes', () => {
     })
 
     it('should return 404 for non-existent product', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(null)
 
       await request(app)
@@ -317,7 +311,11 @@ describe('Product Routes', () => {
     it('should import products from CSV successfully', async () => {
       const response = await request(app)
         .post('/api/products/import/csv')
-        .attach('file', Buffer.from('name,description,price\nTest,Description,29.99'), 'products.csv')
+        .attach(
+          'file',
+          Buffer.from('name,description,price\nTest,Description,29.99'),
+          'products.csv'
+        )
         .field('updateExisting', 'false')
         .field('skipInvalid', 'true')
         .expect(200)
@@ -332,7 +330,7 @@ describe('Product Routes', () => {
 
   describe('POST /api/products/export', () => {
     it('should export products successfully', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
 
       const response = await request(app)
@@ -361,7 +359,7 @@ describe('Product Routes', () => {
 
   describe('GET /api/products/search/suggestions', () => {
     it('should return search suggestions', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findMany.mockResolvedValue([mockProduct])
 
       const response = await request(app)
@@ -396,17 +394,15 @@ describe('Product Routes', () => {
     })
 
     it('should check write permissions for POST endpoints', async () => {
-      const response = await request(app)
-        .post('/api/products')
-        .send({
-          name: 'Test Product',
-          description: 'Test description',
-        })
+      const response = await request(app).post('/api/products').send({
+        name: 'Test Product',
+        description: 'Test description',
+      })
       expect(response.status).toBe(201)
     })
 
     it('should check delete permissions for DELETE endpoints', async () => {
-      const { prisma } = require('../lib/prisma.js')
+      const { prisma } = require('../lib/prisma')
       prisma.product.findFirst.mockResolvedValue(mockProduct)
       prisma.orderItem.count.mockResolvedValue(0)
 

--- a/apps/backend/src/test/test-app.ts
+++ b/apps/backend/src/test/test-app.ts
@@ -41,7 +41,9 @@ vi.mock('../middleware/auth.js', async (importOriginal) => {
     authenticate: vi.fn(() => (req: any, res: any, next: any) => next()),
     requireAuth: vi.fn(() => (req: any, res: any, next: any) => next()),
     requirePermission: vi.fn(() => (req: any, res: any, next: any) => next()),
-    requireAnyPermission: vi.fn(() => (req: any, res: any, next: any) => next()),
+    requireAnyPermission: vi.fn(
+      () => (req: any, res: any, next: any) => next()
+    ),
     requireRole: vi.fn(() => (req: any, res: any, next: any) => next()),
     requireAnyRole: vi.fn(() => (req: any, res: any, next: any) => next()),
   }
@@ -57,7 +59,7 @@ vi.mock('../middleware/validation.js', async (importOriginal) => {
 })
 
 // Mock Prisma
-vi.mock('../lib/prisma.js', () => ({
+vi.mock('../lib/prisma', () => ({
   prisma: {
     product: {
       findMany: vi.fn(),
@@ -248,34 +250,53 @@ export function createTestApp(): Express {
 
 // Helper function to setup common mocks
 export function setupCommonMocks() {
-  const { prisma } = require('../lib/prisma.js')
-  
+  const { prisma } = require('../lib/prisma')
+
   // Setup default mock implementations
   prisma.product.findMany.mockResolvedValue([])
   prisma.product.findFirst.mockResolvedValue(null)
-  prisma.product.create.mockResolvedValue({ id: 'product-1', name: 'Test Product' })
-  prisma.product.update.mockResolvedValue({ id: 'product-1', name: 'Updated Product' })
+  prisma.product.create.mockResolvedValue({
+    id: 'product-1',
+    name: 'Test Product',
+  })
+  prisma.product.update.mockResolvedValue({
+    id: 'product-1',
+    name: 'Updated Product',
+  })
   prisma.product.updateMany.mockResolvedValue({ count: 1 })
   prisma.product.count.mockResolvedValue(0)
   prisma.product.delete.mockResolvedValue({ id: 'product-1' })
-  
+
   prisma.customer.findMany.mockResolvedValue([])
   prisma.customer.findFirst.mockResolvedValue(null)
-  prisma.customer.create.mockResolvedValue({ id: 'customer-1', email: 'test@example.com' })
-  prisma.customer.update.mockResolvedValue({ id: 'customer-1', email: 'updated@example.com' })
+  prisma.customer.create.mockResolvedValue({
+    id: 'customer-1',
+    email: 'test@example.com',
+  })
+  prisma.customer.update.mockResolvedValue({
+    id: 'customer-1',
+    email: 'updated@example.com',
+  })
   prisma.customer.count.mockResolvedValue(0)
-  
+
   prisma.order.findMany.mockResolvedValue([])
   prisma.order.findFirst.mockResolvedValue(null)
   prisma.order.create.mockResolvedValue({ id: 'order-1', status: 'pending' })
   prisma.order.update.mockResolvedValue({ id: 'order-1', status: 'completed' })
   prisma.order.count.mockResolvedValue(0)
-  
-  prisma.user.findFirst.mockResolvedValue({ id: 'user-1', email: 'test@example.com' })
+
+  prisma.user.findFirst.mockResolvedValue({
+    id: 'user-1',
+    email: 'test@example.com',
+  })
   prisma.user.findMany.mockResolvedValue([])
-  
-  prisma.location.findFirst.mockResolvedValue({ id: 'location-1', name: 'Default Location', isDefault: true })
-  
+
+  prisma.location.findFirst.mockResolvedValue({
+    id: 'location-1',
+    name: 'Default Location',
+    isDefault: true,
+  })
+
   prisma.$transaction.mockImplementation(async (callback) => {
     return await callback(prisma)
   })


### PR DESCRIPTION
## Summary
- use extensionless imports for prisma client
- remove unused test variable

## Testing
- `pnpm --filter @oda/backend lint` (fails: @typescript-eslint/no-explicit-any)
- `pnpm lint` (fails: react-hooks/rules-of-hooks)
- `pnpm test:backend` (fails: @prisma/client did not initialize)
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af03891d1c832ba799baa33e01f18d