### PR TITLE
fix: prevent duplicate HTTP responses

### DIFF
--- a/apps/backend/src/lib/api-response.ts
+++ b/apps/backend/src/lib/api-response.ts
@@ -87,7 +87,9 @@ export const sendSuccess = <T>(
       timestamp: new Date().toISOString(),
     },
   }
-
+  if (res.headersSent) {
+    return res
+  }
   return res.status(statusCode).json(response)
 }
 
@@ -145,7 +147,9 @@ export const sendError = (
       requestId,
     },
   }
-
+  if (res.headersSent) {
+    return res
+  }
   return res.status(statusCode).json(response)
 }
 

--- a/apps/backend/src/routes/orders.ts
+++ b/apps/backend/src/routes/orders.ts
@@ -672,9 +672,7 @@ export function createOrderRouter(orderService?: OrderService) {
 
         logger.info('Fulfillment shipped via API', { fulfillmentId, userId })
 
-        res.json(
-          sendSuccess(res, fulfillment, 'Fulfillment shipped successfully')
-        )
+        return sendSuccess(res, fulfillment, 'Fulfillment shipped successfully')
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error'


### PR DESCRIPTION
## Summary
- avoid double response when shipping fulfillment
- guard API response helpers against sending headers twice

## Testing
- `pnpm lint` *(fails: apps/frontend lint: 29 errors)*
- `pnpm --filter @oda/backend lint` *(fails: 16 errors)*
- `pnpm test`
- `pnpm test:backend` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68af13065b10832bb976d0d48ab118ba