### PR TITLE
chore(test): set default test database url

### DIFF
--- a/apps/backend/src/test/setup-env.ts
+++ b/apps/backend/src/test/setup-env.ts
@@ -1,4 +1,6 @@
-process.env.DATABASE_URL ||= 'postgres://localhost:5432/test'
+// Provide default credentials for the test database to avoid
+// Prisma initialization errors during tests.
+process.env.DATABASE_URL ||= 'postgresql://test:test@localhost:5432/test'
 process.env.REDIS_URL ||= 'redis://localhost:6379'
 process.env.ELASTICSEARCH_URL ||= 'http://localhost:9200'
 process.env.RABBITMQ_URL ||= 'amqp://localhost'


### PR DESCRIPTION
## Summary
- provide default DATABASE_URL with test credentials to avoid Prisma access errors during backend tests

## Testing
- `pnpm test`
- `pnpm --filter @oda/backend test src/test/database.test.ts`
- `pnpm --filter @oda/backend test src/test/auth-middleware.test.ts`
- `pnpm --filter @oda/backend test src/test/auth-unit.test.ts`
- `pnpm test:backend` *(fails: Failed to resolve entry for package "@oda/shared" and other test failures)*
- `pnpm --filter @oda/backend lint` *(fails: 84 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68af160b9330832ba15d094c94156179